### PR TITLE
PR 2: scheduler — nightly Ghost→Supabase sync via launchd (closes #3 part B)

### DIFF
--- a/deploy/com.eason.ghost-auto-publish.plist
+++ b/deploy/com.eason.ghost-auto-publish.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.eason.ghost-auto-publish</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>/Users/dljapan/.openclaw/workspace-ghost/deploy/daily_ghost_publish.sh</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>21</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/dljapan/.openclaw/workspace-ghost/logs/scheduler.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/dljapan/.openclaw/workspace-ghost/logs/scheduler.stderr.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>TZ</key>
+    <string>Asia/Tokyo</string>
+  </dict>
+</dict>
+</plist>

--- a/deploy/daily_ghost_publish.sh
+++ b/deploy/daily_ghost_publish.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# daily_ghost_publish.sh — Runs nightly Ghost→Supabase sync.
+#
+# Triggered by:
+#   deploy/com.eason.ghost-auto-publish.plist  (launchd, 21:00 JST)
+#
+# Behavior:
+#   1. Verify Chrome CDP is reachable (required by ghost_backfill_posts.py).
+#   2. If reachable → run ghost_backfill_posts.py to sync any posts published
+#      manually that day into Supabase content_posts (idempotent upsert).
+#   3. Append structured log line to logs/scheduler.log.
+#   4. Exit 0 even on CDP unreachable (don't spam launchd with retries;
+#      absence is captured in the log for later review).
+#
+# Why backfill, not ghost_auto_publish.py:
+#   ghost_auto_publish.py publishes a *specific HTML file*. There's no single
+#   file to publish nightly — content creation is manual. What *can* be
+#   automated is the Supabase sync safety-net, which closes the gap that
+#   caused issue #3 (9-day silent drift from 2026-04-10).
+
+set -u
+
+REPO_DIR="/Users/dljapan/.openclaw/workspace-ghost"
+LOG_DIR="${REPO_DIR}/logs"
+LOG_FILE="${LOG_DIR}/scheduler.log"
+PYTHON="/opt/homebrew/bin/python3.13"
+CDP_PORT="18800"
+
+mkdir -p "${LOG_DIR}"
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { echo "$(ts) [scheduler] $*" >> "${LOG_FILE}"; }
+
+log "run.start tz=Asia/Tokyo local=$(TZ=Asia/Tokyo date +%H:%M)"
+
+if ! curl -sf -o /dev/null --max-time 3 "http://127.0.0.1:${CDP_PORT}/json/version"; then
+  log "run.skip reason=cdp_unreachable port=${CDP_PORT}"
+  log "run.end status=skipped"
+  exit 0
+fi
+
+log "cdp.ok port=${CDP_PORT}"
+
+cd "${REPO_DIR}" || { log "run.fail reason=cd_failed"; exit 0; }
+
+start=$(date +%s)
+if "${PYTHON}" scripts/ghost_backfill_posts.py >> "${LOG_FILE}" 2>&1; then
+  dur=$(( $(date +%s) - start ))
+  log "backfill.ok duration_s=${dur}"
+  log "run.end status=ok"
+else
+  rc=$?
+  dur=$(( $(date +%s) - start ))
+  log "backfill.fail rc=${rc} duration_s=${dur}"
+  log "run.end status=failed"
+fi
+
+exit 0

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -1,0 +1,72 @@
+# Scheduling — Daily Ghost→Supabase Sync
+
+This document explains how the nightly safety-net sync is scheduled, and why it
+uses **launchd** rather than a GitHub Actions workflow.
+
+## What runs
+
+- `scripts/ghost_backfill_posts.py` — reads all published posts from the Ghost
+  Admin API via CDP and idempotently upserts them into Supabase
+  `content_posts`. Runs every night at **21:00 JST**.
+
+## Why launchd, not GitHub Actions
+
+`ghost_auto_publish.py` and `ghost_backfill_posts.py` both connect to the Ghost
+Admin session by attaching to a **locally running Chrome via CDP**
+(`http://127.0.0.1:18800`). This dependency is intentional — it lets the
+scripts reuse Eason's authenticated browser session without storing the Admin
+API key anywhere.
+
+GitHub Actions runners have no such browser, and no way to reach
+`127.0.0.1:18800` on Eason's machine. Two alternatives were considered and
+rejected:
+
+1. **Self-hosted GitHub runner on Eason's Mac** — adds an always-on agent just
+   to trigger one nightly job. Not worth the complexity.
+2. **Refactor scripts to use Ghost Admin API key directly** — viable but out of
+   scope for this PR, and requires a new secret management decision.
+
+`launchd` is macOS's native per-user cron replacement. It fires on the user's
+wall clock (honors `TZ=Asia/Tokyo`), runs only while the user is logged in, and
+has clean stdout/stderr redirection.
+
+## Installation
+
+```bash
+# 1. Copy the plist into user LaunchAgents
+cp deploy/com.eason.ghost-auto-publish.plist \
+   ~/Library/LaunchAgents/com.eason.ghost-auto-publish.plist
+
+# 2. Load it
+launchctl load ~/Library/LaunchAgents/com.eason.ghost-auto-publish.plist
+
+# 3. Verify it's scheduled
+launchctl list | grep ghost-auto-publish
+```
+
+## Verifying it runs
+
+- Structured log: `logs/scheduler.log` — one line per phase
+  (`run.start` / `cdp.ok` / `backfill.ok` / `run.end`).
+- launchd stdout/stderr: `logs/scheduler.stdout.log`,
+  `logs/scheduler.stderr.log`.
+- Manual smoke test:
+
+  ```bash
+  bash deploy/daily_ghost_publish.sh
+  tail -n 20 logs/scheduler.log
+  ```
+
+## Uninstall
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.eason.ghost-auto-publish.plist
+rm ~/Library/LaunchAgents/com.eason.ghost-auto-publish.plist
+```
+
+## Behavior when Chrome/CDP is unavailable
+
+If `http://127.0.0.1:18800/json/version` doesn't respond within 3 seconds, the
+wrapper logs `run.skip reason=cdp_unreachable` and exits 0. This is intentional
+— a failed scheduled run shouldn't retry-storm launchd. The skip is visible in
+`logs/scheduler.log` for the next review.


### PR DESCRIPTION
## Summary

Adds a **nightly (21:00 JST) launchd job** that runs `ghost_backfill_posts.py` to close the 9-day silent-drift gap reported in #3. This is part B of the issue #3 fix (part A = supabase_writer restoration, already merged in PR #5).

## Design decision: launchd over GitHub Actions

The issue tagged **GitHub Action** as the preferred option for traceability, but both `ghost_auto_publish.py` and `ghost_backfill_posts.py` attach to a **locally running Chrome via CDP** (`127.0.0.1:18800`) — reusing Eason's authenticated admin session rather than storing an Admin API key. GitHub Actions runners can't reach that.

Options considered:
- **Self-hosted GHA runner on Eason's Mac** — adds an always-on agent for one nightly job. Not worth it.
- **Refactor scripts to use Ghost Admin API key directly** — viable but scope creep; needs a separate secret-management PR.
- **launchd** (chosen) — native macOS user-level scheduler, honors `TZ=Asia/Tokyo`, clean log redirection, zero new infra.

Rationale is documented in `docs/SCHEDULING.md` so the next engineer understands the choice.

## Why backfill, not ghost_auto_publish.py

The issue wording was "每天 21:00 JST 自动运行 ghost_auto_publish.py", but `ghost_auto_publish.py` publishes a **specific HTML file** passed as argv — there's no single file to publish nightly (content creation is manual). The automatable thing is the **Supabase sync safety-net**: run `ghost_backfill_posts.py` nightly to catch any posts published manually that day. This is exactly what closes the 2026-04-10 drift pattern.

If you actually want scheduled auto-publish of a specific file, that needs a separate queue/spool design.

## Files

- `deploy/com.eason.ghost-auto-publish.plist` — launchd plist, 21:00 JST
- `deploy/daily_ghost_publish.sh` — wrapper that:
  - checks CDP reachable (curl `/json/version`, 3s timeout)
  - runs `scripts/ghost_backfill_posts.py` if reachable
  - logs structured lines to `logs/scheduler.log` (`run.start` / `cdp.ok` / `backfill.ok|fail` / `run.end`)
  - exits 0 on CDP-unreachable (no retry storm)
- `docs/SCHEDULING.md` — install / verify / uninstall / rationale

## Install

```bash
cp deploy/com.eason.ghost-auto-publish.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.eason.ghost-auto-publish.plist
```

## Test plan

- [x] Wrapper script: CDP-reachable path logs `run.start` + `cdp.ok` + proceeds to backfill
- [ ] Wrapper script: CDP-unreachable path logs `run.skip reason=cdp_unreachable` and exits 0 (verifiable by stopping OpenClaw browser and running `bash deploy/daily_ghost_publish.sh`)
- [ ] launchd: after `launchctl load`, `launchctl list | grep ghost-auto-publish` shows entry
- [ ] End-to-end: on next 21:00 JST, `logs/scheduler.log` gets a new `run.start` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)