### PR TITLE
revert: ghost_auto_publish.py 恢复 CDP 方式，移除 Admin API/JWT 依赖

### DIFF
--- a/scripts/ghost_auto_publish.py
+++ b/scripts/ghost_auto_publish.py
@@ -1,69 +1,39 @@
 #!/usr/bin/env python3
 """
-ghost_auto_publish.py — Ghost 自动发布（Admin API + JWT，无浏览器依赖）
+ghost_auto_publish.py — Ghost 自动发布（CDP + mobiledoc HTML Card + 图片上传）
 
 固化流程：
-1. 从 HTML 提取标题/标签/样式+正文（premailer inline CSS）
-2. base64 图片 → POST /ghost/api/admin/images/upload/ → 替换为 URL
-3. mobiledoc HTML Card 创建；更新时自动检测 lexical/mobiledoc
+1. 连接 OpenClaw 已登录浏览器（CDP port 18800）
+2. 从 HTML 提取标题/标签/样式/正文
+3. base64 图片 → 上传 Ghost → 替换为 URL
+4. mobiledoc HTML Card 格式发布（保留完整自定义 CSS）
 
 用法:
   python3 ghost_auto_publish.py <html_file> --slug <short-slug> [--draft] [--update POST_ID]
 
-环境变量:
-  GHOST_ADMIN_KEY  Ghost Admin API key（格式 <id>:<secret>，
-                   在 Ghost → Settings → Integrations 创建 Custom Integration 后获取）
-  GHOST_ADMIN_URL  Ghost 站点根 URL（默认 https://eason.ghost.io）
-
-历史:
-  2026-04-29  改用 Ghost Admin API（REST + JWT），移除 Playwright/CDP 依赖
-              （Chrome 147 + Playwright connect_over_cdp 在脚本环境完全 hang）
+示例:
+  python3 scripts/ghost_auto_publish.py personal-brand/content/drafts/blog.html --slug my-blog
+  python3 scripts/ghost_auto_publish.py blog.html --slug my-blog --update 69afe7b6b3627a0001c730aa
 """
 
-import argparse
-import base64
-import json
-import os
-import re
-import sys
-import time
+import json, re, base64, sys, argparse
 from pathlib import Path
-
-import jwt as pyjwt
-import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _logger import get_logger
 
-# Best-effort .env auto-load — keep optional so the script still runs
-# in environments where python-dotenv isn't installed.
-try:
-    from dotenv import load_dotenv
-    _repo_root = Path(__file__).resolve().parent.parent
-    for _candidate in (_repo_root / ".env", _repo_root / ".env.ghost"):
-        if _candidate.exists():
-            load_dotenv(_candidate, override=False)
-except Exception:
-    pass
-
 log = get_logger("ghost.publish")
-
-DEFAULT_ADMIN_URL = "https://eason.ghost.io"
-API_VERSION = "v5.0"
-JWT_TTL_SECONDS = 5 * 60
-HTTP_TIMEOUT = 60
-HTTP_TIMEOUT_UPLOAD = 120
 
 
 def extract_content(html_path: str) -> dict:
     """从博文 HTML 提取标题、样式+正文、标签、图片
-
+    
     策略：用 premailer 把 CSS inline 到每个 HTML 元素，
     确保 Ghost HTML Card 渲染时不会 strip 掉样式。
     """
     html = Path(html_path).read_text(encoding='utf-8')
 
-    # Title: try hero-title div first, then h1 inside hero/masthead, fallback to any h1, then <title>
+    # Title: try hero-title div first, then h1 inside hero/masthead, fallback to any h1, then <title> tag
     title_match = re.search(r'<div[^>]*class="hero-title"[^>]*>(.*?)</div>', html, re.DOTALL)
     if not title_match:
         title_match = re.search(r'class="(?:hero|masthead)"[^>]*>.*?<h1[^>]*>(.*?)</h1>', html, re.DOTALL)
@@ -72,18 +42,20 @@ def extract_content(html_path: str) -> dict:
     if title_match:
         title = re.sub(r'<[^>]+>', '', title_match.group(1).strip())
     else:
+        # fallback: read from <title> tag, strip the date suffix
         page_title_match = re.search(r'<title>(.*?)</title>', html)
         title = re.sub(r'\s*[|·]\s*20\d\d-\d\d-\d\d.*$', '', page_title_match.group(1)).strip() if page_title_match else "Untitled"
 
-    # Tag from hero-label
+    # Tag from hero-label (includes hidden hero-label for newsletter templates)
     label_match = re.search(r'class="(?:hero-label|series)"[^>]*>(.*?)</div>', html, re.DOTALL)
     tag = re.sub(r'<[^>]+>', '', label_match.group(1).strip()) if label_match else ""
-    if not tag or tag.upper() == tag:
+    # For newsletter templates, use series title as tag
+    if not tag or tag.upper() == tag:  # all-caps = likely CSS class content, not real tag
         series_match = re.search(r'class="series"[^>]*>(.*?)</div>', html, re.DOTALL)
         if series_match:
             tag = re.sub(r'<[^>]+>', '', series_match.group(1).strip())
 
-    # Inline CSS into elements (Ghost HTML Card strips <style> tags)
+    # Inline CSS into elements using premailer (Ghost strips <style> tags from HTML Cards)
     try:
         from premailer import transform
         inlined_html = transform(
@@ -92,19 +64,22 @@ def extract_content(html_path: str) -> dict:
             strip_important=False,
             allow_network=False,
             disable_link_rewrites=True,
-            cssutils_logging_level=40,
+            cssutils_logging_level=40,  # errors only
         )
     except Exception as e:
         print(f"  ⚠️  premailer failed ({e}), falling back to raw HTML")
         inlined_html = html
 
+    # Extract body content from inlined HTML
     body_match = re.search(r'<body[^>]*>(.*)</body>', inlined_html, re.DOTALL)
     body = body_match.group(1).strip() if body_match else inlined_html
 
-    # Strip residual <style> blocks (already inlined)
+    # Remove any residual <style> blocks (already inlined)
     body = re.sub(r'<style[^>]*>.*?</style>', '', body, flags=re.DOTALL)
 
-    # Strip Ghost-only / template-only blocks
+    # Strip Ghost-only / template-only blocks (should never appear in published content)
+    #   .x-box      — X 发布简介框（给作者参考用，不发布）
+    #   .site-footer — 页脚（Ghost 自带页脚，不需要）
     from bs4 import BeautifulSoup as _BS
     _soup = _BS(body, 'html.parser')
     for cls in ['x-box', 'site-footer']:
@@ -114,7 +89,6 @@ def extract_content(html_path: str) -> dict:
 
     # Extract base64 images and replace with placeholders
     img_data_list = []
-
     def replace_b64_img(match):
         full_tag = match.group(0)
         src_match = re.search(r'src="(data:image/[^"]+)"', full_tag)
@@ -133,241 +107,257 @@ def extract_content(html_path: str) -> dict:
     }
 
 
-# ── Ghost Admin API client ────────────────────────────────────────────────
-
-def _admin_credentials() -> tuple[str, str]:
-    raw = os.environ.get("GHOST_ADMIN_KEY", "").strip()
-    if not raw or ":" not in raw:
-        raise RuntimeError(
-            "GHOST_ADMIN_KEY missing or malformed. "
-            "Format: <id>:<secret>. Create a Custom Integration at "
-            "Ghost Admin → Settings → Integrations to obtain one."
-        )
-    kid, secret = raw.split(":", 1)
-    if not kid or not secret:
-        raise RuntimeError("GHOST_ADMIN_KEY malformed: id and secret must both be non-empty")
-    return kid, secret
+def find_ghost_page(playwright_browser):
+    """在已连接的浏览器中找到 Ghost admin 页面"""
+    for context in playwright_browser.contexts:
+        for page in context.pages:
+            if "eason.ghost.io" in page.url:
+                return page
+    return None
 
 
-def _make_token(kid: str, secret: str) -> str:
-    """Generate a short-lived JWT for the Ghost Admin API per docs:
-    https://ghost.org/docs/admin-api/#token-authentication
-    """
-    iat = int(time.time())
-    payload = {"iat": iat, "exp": iat + JWT_TTL_SECONDS, "aud": "/admin/"}
-    headers = {"alg": "HS256", "kid": kid, "typ": "JWT"}
-    return pyjwt.encode(payload, bytes.fromhex(secret), algorithm="HS256", headers=headers)
+def upload_image_to_ghost(ghost_page, data_uri: str, index: int) -> str:
+    """上传单张图片到 Ghost，返回 URL。用 arg 传递避免 evaluate 字符串溢出"""
+    import tempfile, os
+    b64_data = data_uri.split(',', 1)[1] if ',' in data_uri else data_uri
+    mime = 'image/jpeg' if 'image/jpeg' in data_uri else 'image/png'
+    ext = 'jpg' if mime == 'image/jpeg' else 'png'
+
+    # Write to temp file, then use upload_file_to_ghost
+    img_bytes = base64.b64decode(b64_data)
+    tmp_path = f"/tmp/ghost_upload_{index}.{ext}"
+    Path(tmp_path).write_bytes(img_bytes)
+    url = upload_file_to_ghost(ghost_page, tmp_path)
+    os.unlink(tmp_path)
+    return url
 
 
-def _api_url(base: str, path: str) -> str:
-    return f"{base.rstrip('/')}/ghost/api/admin/{path.lstrip('/')}"
+def upload_file_to_ghost(ghost_page, file_path: str) -> str:
+    """上传本地图片文件到 Ghost，返回 URL。分块传入避免 evaluate 溢出"""
+    data = Path(file_path).read_bytes()
+    b64_data = base64.b64encode(data).decode()
+    ext = Path(file_path).suffix.lstrip('.')
+    mime = 'image/jpeg' if ext in ('jpg', 'jpeg') else 'image/png'
+    name = Path(file_path).name
+
+    # Split base64 into chunks and concatenate in browser
+    chunk_size = 50000  # ~50KB per chunk, safe for evaluate
+    chunks = [b64_data[i:i+chunk_size] for i in range(0, len(b64_data), chunk_size)]
+
+    ghost_page.evaluate("window.__img_b64 = '';")
+    for chunk in chunks:
+        # Use JSON.stringify to safely pass the chunk
+        ghost_page.evaluate(f"window.__img_b64 += {json.dumps(chunk)};")
+
+    ghost_page.evaluate(f"window.__img_name = {json.dumps(name)};")
+    ghost_page.evaluate(f"window.__img_mime = {json.dumps(mime)};")
+
+    result = ghost_page.evaluate("""
+        async () => {
+            const b64 = window.__img_b64;
+            const binary = atob(b64);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+            const blob = new Blob([bytes], { type: window.__img_mime });
+            const fd = new FormData();
+            fd.append("file", blob, window.__img_name);
+            const resp = await fetch("/ghost/api/admin/images/upload/", { method: "POST", body: fd });
+            const data = await resp.json();
+            if (data.images && data.images[0]) return { ok: true, url: data.images[0].url };
+            return { ok: false, error: JSON.stringify(data).substring(0, 200) };
+        }
+    """)
+
+    if result.get("ok"):
+        return result["url"]
+    print(f"  ❌ Upload {name}: {result}")
+    return None
 
 
-def _auth_headers(token: str) -> dict:
-    return {"Authorization": f"Ghost {token}", "Accept-Version": API_VERSION}
-
-
-def _api_call(method: str, url: str, token: str, *, expect_json: bool = True, timeout: int = HTTP_TIMEOUT, **kwargs) -> dict:
-    headers = kwargs.pop("headers", {}) or {}
-    headers.update(_auth_headers(token))
-    resp = requests.request(method, url, headers=headers, timeout=timeout, **kwargs)
-    if not resp.ok:
-        body = (resp.text or "")[:400]
-        raise RuntimeError(f"Ghost API {method} {url} → {resp.status_code}: {body}")
-    if not expect_json:
-        return {}
-    try:
-        return resp.json()
-    except ValueError as e:
-        raise RuntimeError(f"Ghost API {method} {url} returned non-JSON: {resp.text[:200]}") from e
-
-
-def upload_image_bytes(base_url: str, token: str, data: bytes, filename: str, mime: str) -> str:
-    url = _api_url(base_url, "images/upload/")
-    files = {"file": (filename, data, mime)}
-    fields = {"ref": filename}
-    headers = _auth_headers(token)
-    resp = requests.post(url, files=files, data=fields, headers=headers, timeout=HTTP_TIMEOUT_UPLOAD)
-    if not resp.ok:
-        raise RuntimeError(f"Ghost image upload {filename} → {resp.status_code}: {resp.text[:300]}")
-    payload = resp.json()
-    if not payload.get("images") or not payload["images"][0].get("url"):
-        raise RuntimeError(f"Ghost image upload {filename} returned no URL: {json.dumps(payload)[:200]}")
-    return payload["images"][0]["url"]
-
-
-def upload_image_b64(base_url: str, token: str, data_uri: str, index: int) -> str:
-    if "," not in data_uri:
-        raise RuntimeError(f"Image #{index}: data URI missing comma separator")
-    mime = "image/jpeg" if "image/jpeg" in data_uri else "image/png"
-    ext = "jpg" if mime == "image/jpeg" else "png"
-    img_bytes = base64.b64decode(data_uri.split(",", 1)[1])
-    return upload_image_bytes(base_url, token, img_bytes, f"upload_{index}.{ext}", mime)
-
-
-def upload_local_image(base_url: str, token: str, file_path: str) -> str:
-    p = Path(file_path)
-    ext = p.suffix.lstrip(".").lower()
-    mime = "image/jpeg" if ext in ("jpg", "jpeg") else f"image/{ext}"
-    return upload_image_bytes(base_url, token, p.read_bytes(), p.name, mime)
-
-
-def get_post(base_url: str, token: str, post_id: str, *, formats: str = "mobiledoc,lexical") -> dict:
-    url = _api_url(base_url, f"posts/{post_id}/?formats={formats}")
-    payload = _api_call("GET", url, token)
-    if not payload.get("posts"):
-        raise RuntimeError(f"Post {post_id} not found")
-    return payload["posts"][0]
-
-
-def create_post(base_url: str, token: str, post: dict) -> dict:
-    url = _api_url(base_url, "posts/")
-    payload = _api_call(
-        "POST", url, token,
-        json={"posts": [post]},
-        headers={"Content-Type": "application/json"},
-    )
-    return payload["posts"][0]
-
-
-def update_post(base_url: str, token: str, post_id: str, post: dict) -> dict:
-    url = _api_url(base_url, f"posts/{post_id}/")
-    payload = _api_call(
-        "PUT", url, token,
-        json={"posts": [post]},
-        headers={"Content-Type": "application/json"},
-    )
-    return payload["posts"][0]
-
-
-# ── Orchestration ─────────────────────────────────────────────────────────
-
-def publish(html_path: str, slug: str = None, do_publish: bool = True, update_id: str = None) -> dict:
-    base_url = os.environ.get("GHOST_ADMIN_URL", DEFAULT_ADMIN_URL).strip() or DEFAULT_ADMIN_URL
-    kid, secret = _admin_credentials()
-    token = _make_token(kid, secret)
+def publish(html_path: str, slug: str = None, do_publish: bool = True, update_id: str = None):
+    from playwright.sync_api import sync_playwright
 
     content = extract_content(html_path)
     print(f"📝 Title: {content['title']}")
     print(f"🏷️  Tag: {content['tag']}")
     print(f"🖼️  Images: {len(content['img_data_list'])}")
 
-    uploaded_urls = []
-    for i, data_uri in enumerate(content["img_data_list"]):
-        url = upload_image_b64(base_url, token, data_uri, i + 1)
-        uploaded_urls.append(url)
-        print(f"  ✅ Image {i+1}: {url}")
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp("http://127.0.0.1:18800")
+        ghost_page = find_ghost_page(browser)
 
-    html_content = content["html"]
-    for url in uploaded_urls:
-        if url and "<!-- IMG_PLACEHOLDER -->" in html_content:
-            img_tag = (
-                f'<img src="{url}" alt="" '
-                f'style="max-width:100%;border-radius:6px;'
-                f'box-shadow:0 2px 12px rgba(0,0,0,0.12);" />'
-            )
-            html_content = html_content.replace("<!-- IMG_PLACEHOLDER -->", img_tag, 1)
+        if not ghost_page:
+            print("❌ Ghost admin page not found. Open https://eason.ghost.io/ghost/ in browser first.")
+            sys.exit(1)
 
-    mobiledoc = json.dumps({
-        "version": "0.3.1",
-        "atoms": [],
-        "cards": [["html", {"html": html_content, "cardWidth": "wide"}]],
-        "markups": [],
-        "sections": [[10, 0]],
-    })
-    status = "published" if do_publish else "draft"
+        print(f"✅ Connected: {ghost_page.url}")
 
-    if update_id:
-        existing = get_post(base_url, token, update_id)
-        post_format = "lexical" if existing.get("lexical") else "mobiledoc"
-        print(f"📦 Post format: {post_format}")
-        payload = {
-            "title": content["title"],
-            "status": status,
-            "tags": [{"name": content["tag"]}] if content["tag"] else [],
-            "updated_at": existing["updated_at"],
-        }
-        if slug:
-            payload["slug"] = slug
-        if post_format == "lexical":
-            payload["lexical"] = json.dumps({
-                "root": {
-                    "children": [{
-                        "type": "html", "version": 1,
-                        "html": html_content, "cardWidth": "wide",
-                    }],
-                    "direction": None, "format": "", "indent": 0,
-                    "type": "root", "version": 1,
-                }
-            })
-            payload["mobiledoc"] = None
+        # --- Upload images ---
+        uploaded_urls = []
+        for i, data_uri in enumerate(content['img_data_list']):
+            url = upload_image_to_ghost(ghost_page, data_uri, i + 1)
+            uploaded_urls.append(url)
+            if url:
+                print(f"  ✅ Image {i+1}: {url}")
+
+        # --- Replace placeholders ---
+        html_content = content['html']
+        for url in uploaded_urls:
+            if url and '<!-- IMG_PLACEHOLDER -->' in html_content:
+                img_tag = f'<img src="{url}" alt="" style="max-width:100%;border-radius:6px;box-shadow:0 2px 12px rgba(0,0,0,0.12);" />'
+                html_content = html_content.replace('<!-- IMG_PLACEHOLDER -->', img_tag, 1)
+
+        # --- Build mobiledoc ---
+        mobiledoc = json.dumps({
+            'version': '0.3.1',
+            'atoms': [],
+            'cards': [['html', {'html': html_content, 'cardWidth': 'wide'}]],
+            'markups': [],
+            'sections': [[10, 0]]
+        })
+
+        status = "published" if do_publish else "draft"
+
+        ghost_page.evaluate(f"window.__mobiledoc = {json.dumps(mobiledoc)};")
+        ghost_page.evaluate(f"window.__title = {json.dumps(content['title'])};")
+        ghost_page.evaluate(f"window.__tag = {json.dumps(content['tag'])};")
+        ghost_page.evaluate(f"window.__slug = {json.dumps(slug or '')};")
+        ghost_page.evaluate(f"window.__status = '{status}';")
+
+        if update_id:
+            # Detect existing post format (mobiledoc vs lexical)
+            post_data = ghost_page.evaluate(f"""
+                async () => {{
+                    const resp = await fetch("/ghost/api/admin/posts/{update_id}/?formats=mobiledoc,lexical");
+                    const data = await resp.json();
+                    const p = data.posts[0];
+                    return {{
+                        updated_at: p.updated_at,
+                        format: p.lexical ? 'lexical' : 'mobiledoc'
+                    }};
+                }}
+            """)
+            post_format = post_data.get('format', 'mobiledoc')
+            print(f"📦 Post format: {post_format}")
+
+            ghost_page.evaluate(f"window.__updated_at = \"{post_data['updated_at']}\";")
+
+            # Build lexical JSON if needed
+            if post_format == 'lexical':
+                lexical = json.dumps({
+                    "root": {
+                        "children": [{"type": "html", "version": 1, "html": html_content, "cardWidth": "wide"}],
+                        "direction": None, "format": "", "indent": 0, "type": "root", "version": 1
+                    }
+                })
+                ghost_page.evaluate(f"window.__lexical = {json.dumps(lexical)};")
+
+            result = ghost_page.evaluate(f"""
+                async () => {{
+                    const p = {{
+                        title: window.__title,
+                        status: window.__status,
+                        tags: window.__tag ? [{{ name: window.__tag }}] : [],
+                        updated_at: window.__updated_at
+                    }};
+                    if ('{post_format}' === 'lexical') {{
+                        p.lexical = window.__lexical;
+                        p.mobiledoc = null;
+                    }} else {{
+                        p.mobiledoc = window.__mobiledoc;
+                    }}
+                    if (window.__slug) p.slug = window.__slug;
+                    const resp = await fetch("/ghost/api/admin/posts/{update_id}/", {{
+                        method: "PUT",
+                        headers: {{ "Content-Type": "application/json" }},
+                        body: JSON.stringify({{ posts: [p] }})
+                    }});
+                    const data = await resp.json();
+                    if (data.posts?.[0]) return {{ ok: true, id: data.posts[0].id, slug: data.posts[0].slug, url: data.posts[0].url, status: data.posts[0].status }};
+                    return {{ ok: false, error: JSON.stringify(data).substring(0, 300) }};
+                }}
+            """)
         else:
-            payload["mobiledoc"] = mobiledoc
-        result = update_post(base_url, token, update_id, payload)
-    else:
-        payload = {
-            "title": content["title"],
-            "mobiledoc": mobiledoc,
-            "status": status,
-            "tags": [{"name": content["tag"]}] if content["tag"] else [],
-        }
-        if slug:
-            payload["slug"] = slug
-        result = create_post(base_url, token, payload)
+            result = ghost_page.evaluate("""
+                async () => {
+                    const p = {
+                        title: window.__title,
+                        mobiledoc: window.__mobiledoc,
+                        status: window.__status,
+                        tags: window.__tag ? [{ name: window.__tag }] : []
+                    };
+                    if (window.__slug) p.slug = window.__slug;
+                    const resp = await fetch("/ghost/api/admin/posts/", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ posts: [p] })
+                    });
+                    const data = await resp.json();
+                    if (data.posts?.[0]) return { ok: true, id: data.posts[0].id, slug: data.posts[0].slug, url: data.posts[0].url, status: data.posts[0].status };
+                    return { ok: false, error: JSON.stringify(data).substring(0, 300) };
+                }
+            """)
 
-    out = {
-        "ok": True,
-        "id": result.get("id"),
-        "slug": result.get("slug"),
-        "url": result.get("url"),
-        "status": result.get("status", status),
-    }
+        if result.get("ok"):
+            print(f"\n{'🟢' if do_publish else '📋'} {'Published' if do_publish else 'Draft created'}")
+            print(f"   ID:     {result['id']}")
+            print(f"   URL:    {result['url']}")
+            print(f"   Slug:   {result['slug']}")
+            print(f"   Status: {result['status']}")
 
-    print(f"\n{'🟢' if do_publish else '📋'} {'Published' if do_publish else 'Draft created'}")
-    print(f"   ID:     {out['id']}")
-    print(f"   URL:    {out['url']}")
-    print(f"   Slug:   {out['slug']}")
-    print(f"   Status: {out['status']}")
+            # ── Supabase content_posts 写入（非阻塞） ──
+            try:
+                from supabase_writer import write_content_post
+                import re as _re
+                _html_text = Path(html_path).read_text(encoding="utf-8")
+                _word_count = len(_re.sub(r'<[^>]+>', '', _html_text).split())
+                write_content_post({
+                    "ghost_id": result.get("id"),
+                    "ghost_slug": result.get("slug"),
+                    "ghost_url": result.get("url"),
+                    "title": content.get("title", ""),
+                    "status": result.get("status", "published"),
+                    "platform": "ghost",
+                    "html_file": str(html_path),
+                    "word_count": _word_count,
+                    "agent": "insight",
+                })
+            except Exception as _e:
+                log.warning("content_post DB write skipped (id=%s slug=%s): %s",
+                            result.get("id"), result.get("slug"), _e, exc_info=True)
 
-    # Supabase content_posts write — failure must surface (RECENT OUTPUT 数据源不能静默)
-    from supabase_writer import write_content_post
-    _html_text = Path(html_path).read_text(encoding="utf-8")
-    _word_count = len(re.sub(r"<[^>]+>", "", _html_text).split())
-    write_content_post({
-        "ghost_id": out["id"],
-        "ghost_slug": out["slug"],
-        "ghost_url": out["url"],
-        "title": content.get("title", ""),
-        "status": out["status"],
-        "platform": "ghost",
-        "html_file": str(html_path),
-        "word_count": _word_count,
-        "agent": "insight",
-    })
+            # ── Supabase blog_posts 写入（非阻塞，已合并至 content_posts） ──
+            # upsert_blog_post 已废弃，写入逻辑在上方 write_content_post 中处理
 
-    if do_publish and out.get("id"):
-        try:
-            verify_post = get_post(base_url, token, out["id"], formats="html")
-            verify_html = verify_post.get("html") or ""
-            verify = {
-                "htmlLength": len(verify_html),
-                "hasCustomStyle": ("8B3A2A" in verify_html) or ("hero" in verify_html),
-                "hasImages": len(re.findall(r"<img", verify_html)),
-            }
-            print("\n🔍 Verification:")
-            print(f"   HTML length: {verify['htmlLength']} chars")
-            print(f"   Custom style: {'✅' if verify['hasCustomStyle'] else '⚠️ NOT FOUND'}")
-            print(f"   Images: {verify['hasImages']}")
-            if verify["htmlLength"] < 100:
-                print("   ⚠️ WARNING: Content appears empty! Check post format (mobiledoc vs lexical).")
-        except Exception as e:
-            log.warning("Post-publish verification skipped: %s", e)
+            # Post-publish verification
+            if do_publish and result.get('id'):
+                verify = ghost_page.evaluate(f"""
+                    async () => {{
+                        const resp = await fetch("/ghost/api/admin/posts/{result['id']}/?formats=html");
+                        const data = await resp.json();
+                        const html = data.posts[0].html || '';
+                        return {{
+                            htmlLength: html.length,
+                            hasCustomStyle: html.includes('8B3A2A') || html.includes('hero'),
+                            hasImages: (html.match(/<img/g) || []).length
+                        }};
+                    }}
+                """)
+                print(f"\n🔍 Verification:")
+                print(f"   HTML length: {verify['htmlLength']} chars")
+                print(f"   Custom style: {'✅' if verify['hasCustomStyle'] else '⚠️ NOT FOUND'}")
+                print(f"   Images: {verify['hasImages']}")
+                if verify['htmlLength'] < 100:
+                    print(f"   ⚠️ WARNING: Content appears empty! Check post format (mobiledoc vs lexical).")
+        else:
+            print(f"\n❌ Failed: {result}")
+            sys.exit(1)
 
-    return out
+        return result
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Ghost Auto Publish (Admin API + JWT)")
+    parser = argparse.ArgumentParser(description="Ghost Auto Publish (CDP + mobiledoc HTML Card)")
     parser.add_argument("html_file", help="Blog HTML file path")
     parser.add_argument("--slug", help="Custom short slug")
     parser.add_argument("--draft", action="store_true", help="Create as draft (default: publish)")
@@ -378,9 +368,4 @@ if __name__ == "__main__":
         print(f"❌ File not found: {args.html_file}")
         sys.exit(1)
 
-    try:
-        publish(args.html_file, slug=args.slug, do_publish=not args.draft, update_id=args.update)
-    except Exception as e:
-        print(f"\n❌ {e}")
-        log.error("publish failed: %s", e, exc_info=True)
-        sys.exit(1)
+    publish(args.html_file, slug=args.slug, do_publish=not args.draft, update_id=args.update)


### PR DESCRIPTION
Closes #10

## 变更内容
- 回退至 ee23bcc（CDP 方式）
- 移除 jwt/pyjwt、GHOST_ADMIN_KEY、requests.post 到 Ghost API 的代码
- 恢复 CDP port 18800 连接已登录浏览器方式
- 保留 premailer / base64 图片 / mobiledoc HTML Card 逻辑