### PR TITLE
fix: ghost_auto_publish 错误处理 + 测试覆盖

### DIFF
--- a/scripts/ghost_auto_publish.py
+++ b/scripts/ghost_auto_publish.py
@@ -25,13 +25,24 @@ from _logger import get_logger
 log = get_logger("ghost.publish")
 
 
+# Timeout for Playwright CDP and network operations (seconds)
+HTTP_TIMEOUT = 30000  # 30s in milliseconds for Playwright
+
+
 def extract_content(html_path: str) -> dict:
     """从博文 HTML 提取标题、样式+正文、标签、图片
     
     策略：用 premailer 把 CSS inline 到每个 HTML 元素，
     确保 Ghost HTML Card 渲染时不会 strip 掉样式。
     """
-    html = Path(html_path).read_text(encoding='utf-8')
+    try:
+        html = Path(html_path).read_text(encoding='utf-8')
+    except FileNotFoundError:
+        log.error("HTML file not found: %s", html_path)
+        raise FileNotFoundError(f"HTML file not found: {html_path}")
+    except PermissionError:
+        log.error("Permission denied reading: %s", html_path)
+        raise
 
     # Title: try hero-title div first, then h1 inside hero/masthead, fallback to any h1, then <title> tag
     title_match = re.search(r'<div[^>]*class="hero-title"[^>]*>(.*?)</div>', html, re.DOTALL)
@@ -81,11 +92,15 @@ def extract_content(html_path: str) -> dict:
     #   .x-box      — X 发布简介框（给作者参考用，不发布）
     #   .site-footer — 页脚（Ghost 自带页脚，不需要）
     from bs4 import BeautifulSoup as _BS
-    _soup = _BS(body, 'html.parser')
-    for cls in ['x-box', 'site-footer']:
-        for el in _soup.find_all(class_=cls):
-            el.decompose()
-    body = str(_soup)
+    try:
+        _soup = _BS(body, 'html.parser')
+        for cls in ['x-box', 'site-footer']:
+            for el in _soup.find_all(class_=cls):
+                el.decompose()
+        body = str(_soup)
+    except Exception as e:
+        log.warning("BeautifulSoup parsing failed, using raw HTML: %s", e)
+        # Fall through with body unchanged
 
     # Extract base64 images and replace with placeholders
     img_data_list = []
@@ -183,7 +198,7 @@ def publish(html_path: str, slug: str = None, do_publish: bool = True, update_id
     print(f"🖼️  Images: {len(content['img_data_list'])}")
 
     with sync_playwright() as p:
-        browser = p.chromium.connect_over_cdp("http://127.0.0.1:18800")
+        browser = p.chromium.connect_over_cdp("http://127.0.0.1:18800", timeout=HTTP_TIMEOUT)
         ghost_page = find_ghost_page(browser)
 
         if not ghost_page:

--- a/tests/test_ghost_publish.py
+++ b/tests/test_ghost_publish.py
@@ -1,0 +1,181 @@
+"""
+test_ghost_publish.py — Tests for ghost_auto_publish.extract_content()
+
+Covers three cases:
+1. Normal HTML with title, tag, body content
+2. Empty HTML (minimal valid structure)
+3. Malformed/garbage HTML input
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+# Add scripts dir to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ghost_auto_publish import extract_content
+import pytest
+
+
+class TestExtractContentNormal:
+    """Test extract_content with well-formed HTML input."""
+
+    def test_extracts_title_from_h1(self, tmp_path):
+        html = """<!DOCTYPE html>
+<html><head><title>Test Post</title></head>
+<body>
+<h1>My Blog Post Title</h1>
+<div class="hero-label">Tech</div>
+<p>Hello world content here.</p>
+</body></html>"""
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert result["title"] == "My Blog Post Title"
+        assert result["tag"] == "Tech"
+        assert "Hello world content" in result["html"]
+        assert isinstance(result["img_data_list"], list)
+
+    def test_extracts_title_from_hero_title_div(self, tmp_path):
+        html = """<!DOCTYPE html>
+<html><head><title>Fallback</title></head>
+<body>
+<div class="hero-title">Hero Title Here</div>
+<p>Body text.</p>
+</body></html>"""
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert result["title"] == "Hero Title Here"
+
+    def test_extracts_base64_images(self, tmp_path):
+        # Create a fake large base64 image (>50KB to trigger extraction)
+        fake_b64 = "data:image/png;base64," + "A" * 60000
+        html = f"""<!DOCTYPE html>
+<html><head><title>Images</title></head>
+<body>
+<h1>Post With Image</h1>
+<img src="{fake_b64}" alt="test" />
+<p>After image.</p>
+</body></html>"""
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert len(result["img_data_list"]) == 1
+        assert "<!-- IMG_PLACEHOLDER -->" in result["html"]
+
+    def test_removes_x_box_and_site_footer(self, tmp_path):
+        html = """<!DOCTYPE html>
+<html><head><title>Clean</title></head>
+<body>
+<h1>Title</h1>
+<div class="x-box">This should be removed</div>
+<p>Keep this.</p>
+<div class="site-footer">Footer removed</div>
+</body></html>"""
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert "x-box" not in result["html"]
+        assert "This should be removed" not in result["html"]
+        assert "Footer removed" not in result["html"]
+        assert "Keep this" in result["html"]
+
+
+class TestExtractContentEmpty:
+    """Test extract_content with empty/minimal HTML."""
+
+    def test_empty_body(self, tmp_path):
+        html = """<!DOCTYPE html>
+<html><head><title></title></head>
+<body></body></html>"""
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert result["title"] == "Untitled" or result["title"] == ""
+        assert result["tag"] == ""
+        assert isinstance(result["img_data_list"], list)
+        assert len(result["img_data_list"]) == 0
+
+    def test_no_h1_falls_back_to_title_tag(self, tmp_path):
+        html = """<!DOCTYPE html>
+<html><head><title>Fallback Title</title></head>
+<body><p>Just a paragraph.</p></body></html>"""
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert result["title"] == "Fallback Title"
+
+    def test_completely_empty_file(self, tmp_path):
+        f = tmp_path / "empty.html"
+        f.write_text("", encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        # Should not crash, returns defaults
+        assert result["title"] == "Untitled"
+        assert result["tag"] == ""
+        assert result["img_data_list"] == []
+
+
+class TestExtractContentMalformed:
+    """Test extract_content with malformed/garbage HTML."""
+
+    def test_garbage_input(self, tmp_path):
+        html = "<div><p>Unclosed tags <span>nested <b>mess"
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        # Should not crash - returns something
+        assert isinstance(result, dict)
+        assert "title" in result
+        assert "html" in result
+        assert isinstance(result["img_data_list"], list)
+
+    def test_binary_garbage(self, tmp_path):
+        # Some non-UTF8 bytes that can still be written as text
+        html = "\\x00\\x01\\x02 <h1>Still Works</h1> \\xff\\xfe"
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert isinstance(result, dict)
+        assert "title" in result
+
+    def test_file_not_found_raises(self):
+        """FileNotFoundError should be raised for non-existent paths."""
+        with pytest.raises(FileNotFoundError):
+            extract_content("/nonexistent/path/file.html")
+
+    def test_script_tags_in_body(self, tmp_path):
+        html = """<!DOCTYPE html>
+<html><head><title>XSS</title></head>
+<body>
+<h1>Normal Title</h1>
+<script>alert('xss')</script>
+<p>Content here.</p>
+</body></html>"""
+        f = tmp_path / "test.html"
+        f.write_text(html, encoding="utf-8")
+
+        result = extract_content(str(f))
+
+        assert result["title"] == "Normal Title"
+        # Script content may or may not be stripped (depends on BS4 config)
+        assert isinstance(result["html"], str)


### PR DESCRIPTION
## 修复内容

1. **Path.read_text() 错误处理** — 包裹 try/except FileNotFoundError + PermissionError，输出明确错误信息
2. **BeautifulSoup 解析防护** — 畸形 HTML 时输出警告而非静默失败/crash
3. **Playwright CDP 连接 timeout** — 定义 HTTP_TIMEOUT=30000ms 并应用到 connect_over_cdp()
4. **新增 test_ghost_publish.py** — 11 个测试覆盖 extract_content() 三种 case（正常/空/畸形输入）

## 验证
```
python3 -c "from ghost_auto_publish import *; print('OK')"  # ✅
pytest tests/test_ghost_publish.py -v  # 11 passed
```